### PR TITLE
Avoid curl | bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,20 @@ MAINTAINER Petr Sloup <petr.sloup@klokantech.com>
 
 RUN apt-get -qq update \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    apt-transport-https \
     curl \
     unzip \
     build-essential \
     python \
     libcairo2-dev \
+    nodejs \
     xvfb \
-&& curl -sL https://deb.nodesource.com/setup_4.x | bash - \
-&& apt-get -y install nodejs \
+&& echo "deb https://deb.nodesource.com/node_4.x jessie main" >> /etc/apt/sources.list.d/nodejs.list \
+&& echo "deb-src https://deb.nodesource.com/node_4.x jessie main" >> /etc/apt/sources.list.d/nodejs.list \
+&& apt-get -qq update \
+&& DEBIAN_FRONTEND=noninteractive apt-get -y --allow-unauthenticated install \
+    nodejs \
+&& rm /etc/apt/sources.list.d/nodejs.list \
 && apt-get clean
 
 RUN mkdir -p /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get -qq update \
     build-essential \
     python \
     libcairo2-dev \
-    nodejs \
     xvfb \
 && echo "deb https://deb.nodesource.com/node_4.x jessie main" >> /etc/apt/sources.list.d/nodejs.list \
 && echo "deb-src https://deb.nodesource.com/node_4.x jessie main" >> /etc/apt/sources.list.d/nodejs.list \


### PR DESCRIPTION
This avoids the arguably risky "curl | bash" with simply adding the repositories directly