### PR TITLE
new feature: command line option for bind address

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ var opts = require('nomnom')
   })
   .option('bind', {
     abbr: 'b',
-    default: "::",
+    default: undefined,
     help: 'Bind address'
   })
   .option('port', {

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,11 @@ var opts = require('nomnom')
     default: 'config.json',
     help: 'Configuration file'
   })
+  .option('bind', {
+    abbr: 'b',
+    default: "::",
+    help: 'Bind address'
+  })
   .option('port', {
     abbr: 'p',
     default: 8080,
@@ -24,5 +29,6 @@ var opts = require('nomnom')
 
 return require('./server')({
   config: opts.config,
+  bind: opts.bind,
   port: opts.port
 });

--- a/src/server.js
+++ b/src/server.js
@@ -284,7 +284,7 @@ module.exports = function(opts, callback) {
     return data;
   });
 
-  var server = app.listen(process.env.PORT || opts.port, function() {
+  var server = app.listen(process.env.PORT || opts.port, process.env.BIND || opts.bind, function() {
     console.log('Listening at http://%s:%d/',
                 this.address().address, this.address().port);
 


### PR DESCRIPTION
I ported this PR direktly in github, without checking the coude out / testing, but it should be OK, I think.

I created this github "organization" to be able to fork the original tileserver, since I got:

"You already have a fork of this repository: efi/tileserver-gl-light"