### PR TITLE
Support fontstacks.json

### DIFF
--- a/src/serve_font.js
+++ b/src/serve_font.js
@@ -27,6 +27,11 @@ module.exports = function(options, allowedFonts) {
     });
   });
 
+  app.get('/fontstacks.json', function(req, res, next) {
+    res.header('Content-type', 'application/json');
+    return res.send(Object.keys(existingFonts));
+  });
+
   app.get('/:fontstack/:range([\\d]+-[\\d]+).pbf',
       function(req, res, next) {
     var fontstack = decodeURI(req.params.fontstack);


### PR DESCRIPTION
Supports fontstacks.json for #101. I don't want to dig into allowed fonts but this at least provides a fontstack.json