### PR TITLE
add `--cors` option to allow for optional CORS handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,10 @@ var opts = require('nomnom')
     default: 8080,
     help: 'Port'
   })
+  .option('cors', {
+    default: true,
+    help: 'Enable Cross-origin resource sharing headers'
+  })
   .option('verbose', {
     abbr: 'V',
     flag: true,
@@ -54,7 +58,8 @@ var startServer = function(configPath, config) {
     configPath: configPath,
     config: config,
     bind: opts.bind,
-    port: opts.port
+    port: opts.port,
+    cors: opts.cors
   });
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -90,7 +90,9 @@ module.exports = function(opts, callback) {
 
   var data = clone(config.data || {});
 
-  app.use(cors());
+  if (opts.cors) {
+    app.use(cors());
+  }
 
   Object.keys(config.styles || {}).forEach(function(id) {
     var item = config.styles[id];


### PR DESCRIPTION
we are using `cors` middleware with default options which works for most
applications, but does not allow for fine tuning (whitelisting origins
etc.)

this change keeps CORS handling as default to preserve compatibility but
also allows for specying `--no-cors` option which makes it possible to
handle CORS in an independent proxy (NGINX, another node app etc.)