### PR TITLE
Reload configuration on SIGHUP

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "test": "mocha test/**.js"
   },
   "dependencies": {
-    "async": "2.2.0",
+    "@mapbox/mapbox-gl-native": "3.4.4",
+    "@mapbox/sphericalmercator": "1.0.5",
     "advanced-pool": "0.3.2",
+    "async": "2.2.0",
     "base64url": "2.0.0",
     "canvas": "1.6.5",
     "clone": "2.1.1",
@@ -29,6 +31,7 @@
     "express": "4.15.2",
     "glyph-pbf-composite": "0.0.2",
     "handlebars": "4.0.6",
+    "http-shutdown": "^1.2.0",
     "mbtiles": "0.9.0",
     "morgan": "1.8.1",
     "node-pngquant-native": "1.0.4",
@@ -38,9 +41,7 @@
     "request": "2.81.0",
     "sharp": "0.17.2",
     "tileserver-gl-styles": "1.1.1",
-    "vector-tile": "1.3.0",
-    "@mapbox/mapbox-gl-native": "3.4.4",
-    "@mapbox/sphericalmercator": "1.0.5"
+    "vector-tile": "1.3.0"
   },
   "devDependencies": {
     "should": "^11.2.0",


### PR DESCRIPTION
I'm opening this PR to hear thoughts on how people think #22 should be implemented.

This brings in [`http-shutdown`](https://www.npmjs.com/package/http-shutdown) for gracefully closing the server before reloading the config.  If there is concern about the extra record keeping for tracking connections, [`server-destroy`](https://www.npmjs.com/package/server-destroy) is slightly lighter alternative, but this would mean a hard shutdown after some fixed timeout.

In order to reload the config and styles, the entire `require.cache` is cleared.  If this is a concern, a more selective cache clearing could work, but I think there would probably be marginal benefit.

I also made it so the `callback` is only called once (previously it was called [on `'listening'`](https://github.com/klokantech/tileserver-gl/blob/49a779970e3443bffaf2c5f58e0e491ab21fb6d3/src/server.js#L363) and [after 1000 ms](https://github.com/klokantech/tileserver-gl/blob/49a779970e3443bffaf2c5f58e0e491ab21fb6d3/src/server.js#L370).  It looks to me like this is never used, but I'm not sure if people are requiring this module directly and relying on the current callback behavior.
