### PR TITLE
Remove unused callback

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -28,7 +28,7 @@ if (!isLight) {
   serve_rendered = require('./serve_rendered');
 }
 
-module.exports = function(opts, callback) {
+module.exports = function(opts) {
   console.log('Starting server');
 
   var app = express().disable('x-powered-by'),
@@ -40,8 +40,6 @@ module.exports = function(opts, callback) {
       };
 
   app.enable('trust proxy');
-
-  callback = callback || function() {};
 
   if (process.env.NODE_ENV == 'production') {
     app.use(morgan('tiny'));
@@ -359,15 +357,12 @@ module.exports = function(opts, callback) {
   var server = app.listen(process.env.PORT || opts.port, process.env.BIND || opts.bind, function() {
     console.log('Listening at http://%s:%d/',
                 this.address().address, this.address().port);
-
-    return callback();
   });
 
   process.on('SIGINT', function() {
       process.exit();
   });
 
-  setTimeout(callback, 1000);
   return {
     app: app,
     server: server


### PR DESCRIPTION
The `callback` provided to the main server export is called twice on success (once on `'listening'` and once after 1000 ms).  The callback is not being used elsewhere in the repo, so in case it isn't actually required, this pull request proposes removing it.

It's very possible that I'm missing something about how the callback is used.  No offense if you close this :).