### PR TITLE
Enclose literal IPv6 addresses in brackets

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -355,8 +355,11 @@ module.exports = function(opts) {
   });
 
   var server = app.listen(process.env.PORT || opts.port, process.env.BIND || opts.bind, function() {
-    console.log('Listening at http://%s:%d/',
-                this.address().address, this.address().port);
+    var address = this.address().address;
+    if (address.indexOf('::') === 0) {
+      address = '[' + address + ']'; // literal IPv6 address
+    }
+    console.log('Listening at http://%s:%d/', address, this.address().port);
   });
 
   process.on('SIGINT', function() {


### PR DESCRIPTION
Minor change, but this makes it easier to use the logged URL if an IPv6 address is used (the literal address is [enclosed in brackets](https://en.wikipedia.org/wiki/IPv6_address#Literal_IPv6_addresses_in_network_resource_identifiers) to avoid conflict with the `:` separator for the port).

E.g.
```
Listening at http://[::]:8080/
```
