### PR TITLE
Log errors to stderr and return

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -223,7 +223,7 @@ module.exports = function(options, repo, params, id, dataResolver) {
         }
         mbtilesFile = dataResolver(mbtilesFile);
         if (!mbtilesFile) {
-          console.log('ERROR: data "' + mbtilesFile + '" not found!');
+          console.error('ERROR: data "' + mbtilesFile + '" not found!');
           process.exit(1);
         }
       }
@@ -238,6 +238,7 @@ module.exports = function(options, repo, params, id, dataResolver) {
           map.sources[name].getInfo(function(err, info) {
             if (err) {
               console.error(err);
+              return;
             }
 
             if (!dataProjWGStoInternalWGS && info.proj4) {
@@ -348,7 +349,10 @@ module.exports = function(options, repo, params, id, dataResolver) {
       }
       renderer.render(params, function(err, data) {
         pool.release(renderer);
-        if (err) console.log(err);
+        if (err) {
+          console.error(err);
+          return;
+        }
 
         var image = sharp(data, {
           raw: {


### PR DESCRIPTION
This makes it so errors in `serve_rendered.js` are written to `stderr`.  The `return`s are to avoid additional errors when the second arg to the callback is not defined.  It may be that the correct behavior is to reject (at least in [the first case](https://github.com/tschaub/tileserver-gl/blob/de83021c3db53a4b258f119e7f683e51bade02f8/src/serve_rendered.js#L240)) or otherwise handle the error.