### PR TITLE
Use debian stretch nodejs repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get -qq update \
     libprotobuf-dev \
     libxxf86vm-dev \
     xvfb \
-&& echo "deb https://deb.nodesource.com/node_6.x jessie main" >> /etc/apt/sources.list.d/nodejs.list \
-&& echo "deb-src https://deb.nodesource.com/node_6.x jessie main" >> /etc/apt/sources.list.d/nodejs.list \
+&& echo "deb https://deb.nodesource.com/node_6.x stretch main" >> /etc/apt/sources.list.d/nodejs.list \
+&& echo "deb-src https://deb.nodesource.com/node_6.x stretch main" >> /etc/apt/sources.list.d/nodejs.list \
 && apt-get -qq update \
 && DEBIAN_FRONTEND=noninteractive apt-get -y --allow-unauthenticated install \
     nodejs \


### PR DESCRIPTION
Dockerfile based on `debian:stretch`, so better to use native `stretch` nodejs repo instead of `jessie` repo.