### PR TITLE
ADD support for encoded path

### DIFF
--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -36,6 +36,7 @@ Static images
     * e.g. ``5.9,45.8|5.9,47.8|10.5,47.8|10.5,45.8|5.9,45.8``
 
   * ``encodedpath`` - an alternative way to provide a path using Google's polyline encoding. Only used if ``path`` is not provided.
+    
     * more details: https://developers.google.com/maps/documentation/utilities/polylinealgorithm
   * ``latlng`` - indicates the ``path`` coordinates are in ``lat,lng`` order rather than the usual ``lng,lat``. possible values: ``true`` or ``1``
   * ``fill`` - color to use as the fill (e.g. ``red``, ``rgba(255,255,255,0.5)``, ``#0000ff``)

--- a/docs/endpoints.rst
+++ b/docs/endpoints.rst
@@ -35,7 +35,9 @@ Static images
 
     * e.g. ``5.9,45.8|5.9,47.8|10.5,47.8|10.5,45.8|5.9,45.8``
 
-  * ``latlng`` - indicates the ``path`` coordinates are in ``lat,lng`` order rather than the usual ``lng,lat``
+  * ``encodedpath`` - an alternative way to provide a path using Google's polyline encoding. Only used if ``path`` is not provided.
+    * more details: https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+  * ``latlng`` - indicates the ``path`` coordinates are in ``lat,lng`` order rather than the usual ``lng,lat``. possible values: ``true`` or ``1``
   * ``fill`` - color to use as the fill (e.g. ``red``, ``rgba(255,255,255,0.5)``, ``#0000ff``)
   * ``stroke`` - color of the path stroke
   * ``width`` - width of the stroke

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -504,6 +504,11 @@ module.exports = function(options, repo, params, id, dataResolver) {
         path.push(pair);
       }
     });
+
+    if(path.length==0){
+      path = utils.decodePolyline(query.encodedpath);
+    }
+
     return path;
   };
 

--- a/src/server.js
+++ b/src/server.js
@@ -185,6 +185,20 @@ function start(opts) {
     );
   });
 
+  app.get('/new-user', function(req, res){
+    var userId = req.query.id;
+    var id = "heatmap-"+userId;
+    var item = {
+      mbtiles: "heatmap-"+userId+".mbtiles"
+    }
+    
+    serve_data(options, serving.data, item, id, serving.styles).then(function(sub) {
+        console.log("# serve data")
+        app.use('/data/', sub);
+        res.send("ok")
+    });
+  });
+
   app.get('/styles.json', function(req, res, next) {
     var result = [];
     var query = req.query.key ? ('?key=' + req.query.key) : '';

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,3 +116,57 @@ module.exports.getFontsPbf = function(allowedFonts, fontPath, names, range, fall
     }, reject);
   });
 };
+
+// From: https://github.com/mapbox/polyline/blob/master/src/polyline.js
+module.exports.decodePolyline = function(str, precision) {
+    var index = 0,
+        lat = 0,
+        lng = 0,
+        coordinates = [],
+        shift = 0,
+        result = 0,
+        byte = null,
+        latitude_change,
+        longitude_change,
+        factor = Math.pow(10, precision || 5);
+
+    if(str==null){
+      return [];
+    }
+
+    // Coordinates have variable length when encoded, so just keep
+    // track of whether we've hit the end of the string. In each
+    // loop iteration, a single coordinate is decoded.
+    while (index < str.length) {
+
+        // Reset shift, result, and byte
+        byte = null;
+        shift = 0;
+        result = 0;
+
+        do {
+            byte = str.charCodeAt(index++) - 63;
+            result |= (byte & 0x1f) << shift;
+            shift += 5;
+        } while (byte >= 0x20);
+
+        latitude_change = ((result & 1) ? ~(result >> 1) : (result >> 1));
+
+        shift = result = 0;
+
+        do {
+            byte = str.charCodeAt(index++) - 63;
+            result |= (byte & 0x1f) << shift;
+            shift += 5;
+        } while (byte >= 0x20);
+
+        longitude_change = ((result & 1) ? ~(result >> 1) : (result >> 1));
+
+        lat += latitude_change;
+        lng += longitude_change;
+
+        coordinates.push([lng / factor, lat / factor]);
+    }
+
+    return coordinates;
+};


### PR DESCRIPTION
The current way of sending the path generates a very long URL. An alternative way of providing the path coordinates is by using Google polyline encoding algorithm.

Also the docs for the latlng parameter did not state the value that should be sent.