### PR TITLE
Wait for X server, Xvfb, to come up. Solves Issue #197

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qq update \
     libprotobuf-dev \
     libxxf86vm-dev \
     xvfb \
+    x11-utils \
 && echo "deb https://deb.nodesource.com/node_6.x stretch main" >> /etc/apt/sources.list.d/nodejs.list \
 && echo "deb-src https://deb.nodesource.com/node_6.x stretch main" >> /etc/apt/sources.list.d/nodejs.list \
 && apt-get -qq update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qq update \
     libprotobuf-dev \
     libxxf86vm-dev \
     xvfb \
+    netcat \
 && echo "deb https://deb.nodesource.com/node_6.x stretch main" >> /etc/apt/sources.list.d/nodejs.list \
 && echo "deb-src https://deb.nodesource.com/node_6.x stretch main" >> /etc/apt/sources.list.d/nodejs.list \
 && apt-get -qq update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get -qq update \
     libprotobuf-dev \
     libxxf86vm-dev \
     xvfb \
-    netcat \
 && echo "deb https://deb.nodesource.com/node_6.x stretch main" >> /etc/apt/sources.list.d/nodejs.list \
 && echo "deb-src https://deb.nodesource.com/node_6.x stretch main" >> /etc/apt/sources.list.d/nodejs.list \
 && apt-get -qq update \

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/klokantech/tileserver-gl.git"
+    "url": "https://github.com/polar/tileserver-gl.git"
   },
   "license": "BSD-2-Clause",
   "engines": {

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
-sleep 1
+
+timeout 15 bash -c 'until echo > /dev/tcp/localhost/99; do sleep 0.5; done'
 
 export DISPLAY=:99.0
 

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ if [ "${port}" != "" ]; then
         -ac +extension GLX +render -noreset
 
     # Wait to be able to connect to the port. This will exit if it cannot in 15 minutes.
-    timeout 15 bash -c "until echo > /dev/tcp/localhost/${port}; do sleep 0.5; done"
+    timeout 15 bash -c "while ! nc -z localhost ${port}; do sleep 0.5; done"
     export DISPLAY=:${port}.0
 
     cd /data

--- a/run.sh
+++ b/run.sh
@@ -12,8 +12,8 @@ while [ ${p} -lt 3000 ]
     fi
  done
 
-if ${port}; then
-    echo The display port will be ${port}
+if "${port}" != ""; then
+    echo "The display port will be ${port}."
     start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background \
         --exec /usr/bin/Xvfb -- :${port} -screen 0 1024x768x24 \
         -ac +extension GLX +render -noreset
@@ -25,6 +25,6 @@ if ${port}; then
     cd /data
     node /usr/src/app/ -p 80 "$@"
 else
-    echo "Could get a display port ${port}."
+    echo "Could not get a display port."
     exit 1
 fi

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,8 @@ while [ ${p} -lt 3000 ]
     fi
  done
 
+let timeout=20
+
 if [ "${port}" != "" ]; then
     echo "The display port will be ${port}."
     start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background \
@@ -19,14 +21,14 @@ if [ "${port}" != "" ]; then
         -ac +extension GLX +render -noreset
 
     # Wait to be able to connect to the port. This will exit if it cannot in 15 minutes.
-    timeout 15 bash -c "while ! nc -z localhost ${port}; do sleep 0.5; done"
+    timeout ${timeout} bash -c "while ! nc -z localhost ${port}; do sleep 0.5; done"
     if [ $? -eq 0 ]; then
         export DISPLAY=:${port}.0
 
         cd /data
         node /usr/src/app/ -p 80 "$@"
     else
-      echo "Could not connect to display port ${port} in 15 seconds time."
+      echo "Could not connect to display port ${port} in ${timeout} seconds time."
     fi
 else
     echo "Could not get a display port."

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ while [ ${p} -lt 3000 ]
         break
     fi
  done
- echo The port is ${port}
+echo The port is ${port}
 
 if ${port}; then
     timeout 15 bash -c "until echo > /dev/tcp/localhost/${port}; do sleep 0.5; done"

--- a/run.sh
+++ b/run.sh
@@ -20,10 +20,14 @@ if [ "${port}" != "" ]; then
 
     # Wait to be able to connect to the port. This will exit if it cannot in 15 minutes.
     timeout 15 bash -c "while ! nc -z localhost ${port}; do sleep 0.5; done"
-    export DISPLAY=:${port}.0
+    if [ $? -eq 0 ]; then
+        export DISPLAY=:${port}.0
 
-    cd /data
-    node /usr/src/app/ -p 80 "$@"
+        cd /data
+        node /usr/src/app/ -p 80 "$@"
+    else
+      echo "Could not connect to display port ${port} in 15 seconds time."
+    fi
 else
     echo "Could not get a display port."
     exit 1

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
 
-timeout 15 bash -c 'until echo > /dev/tcp/localhost/99; do sleep 0.5; done'
+let p=80
+while [ ${p} -lt 3000 ]
+ do
+    if nc -z localhost ${p}; then
+        let p+=1
+    else
+        let port=p
+        break
+    fi
+ done
+ echo The port is ${port}
 
-export DISPLAY=:99.0
+if ${port}; then
+    timeout 15 bash -c "until echo > /dev/tcp/localhost/${port}; do sleep 0.5; done"
+else
+    exit 1
+fi
+
+export DISPLAY=:${port}.0
 
 cd /data
 node /usr/src/app/ -p 80 "$@"

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,8 @@ function LOG {
     echo $(date -R): $0: $*
 }
 
+timeout=30
+
 displayNumber=1
 screenNumber=0
 export DISPLAY=:${displayNumber}.${screenNumber}

--- a/run.sh
+++ b/run.sh
@@ -18,7 +18,7 @@ LOG "Starting Xvfb on ${DISPLAY}"
 LOG "Waiting for display at ${DISPLAY}."
 
 # Wait to be able to connect to the port. This will exit if it cannot in 15 minutes.
-timeout ${timeout} bash -c "while  ! xdpyinfo >/dev/null 2>&1; do sleep 0.5; done"
+timeout ${timeout} bash -c "while  ! xdpyinfo; do sleep 0.5; done"
 if [ $? -eq 0 ]; then
     LOG "Display ${DISPLAY} is up."
     LOG "Starting tileserver"

--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,7 @@ while [ ${p} -lt 3000 ]
     fi
  done
 
-if "${port}" != ""; then
+if [ "${port}" != "" ]; then
     echo "The display port will be ${port}."
     start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background \
         --exec /usr/bin/Xvfb -- :${port} -screen 0 1024x768x24 \


### PR DESCRIPTION
This pull request will properly solve Issue #197: https://github.com/klokantech/tileserver-gl/issues/197
**Strange error with docker container : libEGL warning: DRI3: xcb_connect failed** 

This solves the problem by adding x11-utils to the Dockerfile and using xdpyinfo repeatedly until the Xvfb server is up.

This pull request may have to be changed a bit, in that I've modified the package.json to point to my repository.  Perhaps I should have created a branch? Anyway, you get the general idea.