### PR TITLE
Make raster tile renderer pool sizes configurable

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -95,6 +95,27 @@ Maximum image side length to be allowed to be rendered (including scale factor).
 Be careful when changing this value since there are hardware limits that need to be considered.
 Default is ``2048``.
 
+``minRendererPoolSizes``
+------------------------
+
+Minimum amount of raster tile renderers per scale factor.
+The value is an array: the first element is the minimum amount of renderers for scale factor one, the second for scale factor two and so on.
+If the array has less elements than ``maxScaleFactor``, then the last element is used for all remaining scale factors as well.
+Selecting renderer pool sizes is a trade-off between memory use and speed.
+A reasonable value will depend on your hardware and your amount of styles and scale factors.
+If you have plenty of memory, you'll want to set this equal to ``maxRendererPoolSizes`` to avoid increased latency due to renderer destruction and recreation.
+If you need to conserve memory, you'll want something lower than ``maxRendererPoolSizes``, possibly allocating more renderers to scale factors that are more common.
+Default is ``[8, 4, 2]``.
+
+``maxRendererPoolSizes``
+------------------------
+
+Maximum amount of raster tile renderers per scale factor.
+The value and considerations are similar to ``minRendererPoolSizes`` above.
+If you have plenty of memory, try setting these equal to or slightly above your processor count, e.g. if you have four processors, try a value of ``[6]``.
+If you need to conserve memory, try lower values for scale factors that are less common.
+Default is ``[16, 8, 4]``.
+
 ``watermark``
 -----------
 

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -344,18 +344,15 @@ module.exports = function(options, repo, params, id, dataResolver) {
   });
 
   var renderersReadyPromise = Promise.all(queue).then(function() {
-    // TODO: make pool sizes configurable
+    // standard and @2x tiles are much more usual -> default to larger pools
+    var minPoolSizes = options.minRendererPoolSizes || [8, 4, 2];
+    var maxPoolSizes = options.maxRendererPoolSizes || [16, 8, 4];
     for (var s = 1; s <= maxScaleFactor; s++) {
-      var minPoolSize = 2;
-
-      // standard and @2x tiles are much more usual -> create larger pools
-      if (s <= 2) {
-        minPoolSize *= 2;
-        if (s <= 1) {
-          minPoolSize *= 2;
-        }
-      }
-      map.renderers[s] = createPool(s, minPoolSize, 2 * minPoolSize);
+      var i = Math.min(minPoolSizes.length - 1, s - 1);
+      var j = Math.min(maxPoolSizes.length - 1, s - 1);
+      var minPoolSize = minPoolSizes[i];
+      var maxPoolSize = Math.max(minPoolSize, maxPoolSizes[j]);
+      map.renderers[s] = createPool(s, minPoolSize, maxPoolSize);
     }
   });
 


### PR DESCRIPTION
Here's a change to make the raster tile renderer pool sizes configurable in the configuration file. Details of how it works are in the config file diff.

At first I thought for simplicity that I'd use a single value for all scale factors, but I concluded it would have been confusing if the default value depends on the scale factor, but it wouldn't have been configurable at that level. Allowing arrays shorter than `maxScaleFactor` should keep this simple enough to configure.