### PR TITLE
Catch incorrect header exceptions

### DIFF
--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -192,7 +192,7 @@ module.exports = function(options, repo, params, id, dataResolver) {
                   response.data = zlib.unzipSync(data);
                 }
                 catch (err) {
-                  console.log("Skipping incorrect header for tile mbtiles://openmaptiles/%z/%x/%y.pbf", z, x, y);
+                  console.log("Skipping incorrect header for tile mbtiles://%s/%s/%s/%s.pbf", id, z, x, y);
                 }
                 if (options.dataDecoratorFunc) {
                   response.data = options.dataDecoratorFunc(

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -188,7 +188,12 @@ module.exports = function(options, repo, params, id, dataResolver) {
               }
 
               if (format == 'pbf') {
-                response.data = zlib.unzipSync(data);
+                try {
+                  response.data = zlib.unzipSync(data);
+                }
+                catch (err) {
+                  console.log("Skipping incorrect header for tile mbtiles://openmaptiles/%z/%x/%y.pbf", z, x, y);
+                }
                 if (options.dataDecoratorFunc) {
                   response.data = options.dataDecoratorFunc(
                     sourceId, 'data', response.data, z, x, y);


### PR DESCRIPTION
A tile in our data is corrupted. As a result its header is not correct, and this causes the server to crash. We know which exact tile is broken in our data, so we can reproduce the problem.

```
zlib.js:560
throw error;
^
Error: incorrect header check
at Zlib._handle.onerror (zlib.js:370:17)
at Unzip.Zlib._processChunk (zlib.js:550:30)
at zlibBufferSync (zlib.js:239:17)
at Object.exports.unzipSync (zlib.js:151:10)
at /usr/src/app/src/serve_rendered.js:185:38
at Statement.<anonymous> (/usr/src/app/node_modules/@mapbox/mbtiles/lib/mbtiles.js:166:20)
Segmentation fault (core dumped)`
```


