### PR TITLE
Addresses issue #197, send SIGTERM through to node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV NODE_ENV="production"
 VOLUME /data
 WORKDIR /data
 EXPOSE 80
-ENTRYPOINT ["/usr/src/app/run.sh"]
+ENTRYPOINT ["/bin/bash", "/usr/src/app/run.sh"]
 
 RUN apt-get -qq update \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install \

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+
+_term() {
+	echo "Caught signal, stopping gracefully"
+	kill -TERM "$child" 2>/dev/null
+}
+
+trap _term TERM
+
+
 start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
 echo "Waiting 3 seconds for xvfb to start..."
 sleep 3
@@ -6,7 +15,9 @@ sleep 3
 export DISPLAY=:99.0
 
 cd /data
-node /usr/src/app/ -p 80 "$@"
+node /usr/src/app/ -p 80 "$@" &
+child=$!
+wait "$child"
 
 start-stop-daemon --stop --pidfile ~/xvfb.pid # stop xvfb when exiting
 rm ~/xvfb.pid


### PR DESCRIPTION
Node can't be PID 1, else it can't be term'ed and xvfb won't stop nicely.  So, according to https://docs.docker.com/engine/reference/builder/#entrypoint, we need to make sure it's not the bare entrypoint.

Also we need to be sure that run.sh passes the signal through to node, see https://unix.stackexchange.com/questions/146756/forward-sigterm-to-child-in-bash