### PR TITLE
adds bundled dependency tileserver-gl-styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "should": "^11.2.0",
     "mocha": "^3.2.0",
     "supertest": "^3.0.0"
-  }
+  },
+  "bundledDependencies": [
+    "tileserver-gl-styles"
+  ]
 }


### PR DESCRIPTION
When installing without the global flag, npm installs the `tileserver-gl-styles` dependency at the same level as tileserver-gl.

```bash
node_modules
.
├── ...
├── tileserver-gl
├── tileserver-gl-styles
└── ...
```
This results in <a href="https://github.com/klokantech/tileserver-gl/blob/master/src/main.js#L86" target="_blank">src/main.js</a> trying to resolve the wrong path, throwing an  `Error: ENOENT: no such file or directory, scandir <path>/node_modules/tileserver-gl/node_modules/tileserver-gl-styles/styles`.

This can be tested verified with the following package.json and running `npm install` followed by `npm run test`.

```javascript
{
  "scripts": {
    "test": "tileserver-gl zurich_switzerland.mbtiles"
  },
  "dependencies": {
    "tileserver-gl": "^2.3.1"
  }
}
```
This PR adds `tileserver-gl-styles` to the bundled dependencies, ensuring it's path is properly resolved:

```bash
node_modules
.
├── ...
├── tileserver-gl
│   └── node_modules
│       └── tileserver-gl-styles
└── ...
```