### PR TITLE
Return 204 when mbtiles error is 'Tile does not exist'

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -89,7 +89,7 @@ module.exports = function(options, repo, params, id, styles) {
     source.getTile(z, x, y, function(err, data, headers) {
       if (err) {
         if (/does not exist/.test(err.message)) {
-          return res.status(404).send(err.message);
+          return res.status(204).send(err.message);
         } else {
           return res.status(500).send(err.message);
         }

--- a/test/tiles_data.js
+++ b/test/tiles_data.js
@@ -23,6 +23,6 @@ describe('Vector tiles', function() {
     testTile(prefix, 0, 1, 0, 404);
     testTile(prefix, 0, 0, 1, 404);
 
-    testTile(prefix, 14, 0, 0, 404); // non existent tile
+    testTile(prefix, 14, 0, 0, 204); // non existent tile
   });
 });


### PR DESCRIPTION
Result status code changed from 404 to 204 when mbtiles error is 'Tile does not exist'  (due to issue #46 )