### PR TITLE
Update commander and devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "canvas": "1.6.8",
     "clone": "2.1.1",
     "color": "1.0.3",
-    "commander": "2.16.0",
+    "commander": "2.17.1",
     "cors": "2.8.4",
     "express": "4.16.2",
     "glyph-pbf-composite": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "canvas": "1.6.8",
     "clone": "2.1.1",
     "color": "1.0.3",
-    "commander": "2.1.0",
+    "commander": "2.16.0",
     "cors": "2.8.4",
     "express": "4.16.2",
     "glyph-pbf-composite": "0.0.2",
@@ -42,8 +42,8 @@
     "tileserver-gl-styles": "1.2.0"
   },
   "devDependencies": {
-    "should": "^11.2.0",
-    "mocha": "^3.2.0",
-    "supertest": "^3.0.0"
+    "mocha": "^3.5.3",
+    "should": "^11.2.1",
+    "supertest": "^3.1.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -35,8 +35,8 @@ var opts = require('commander')
   .option(
     '-p, --port <port>',
     'Port [8080]',
-    parseInt,
-    8080
+    8080,
+    parseInt
   )
   .option(
     '-C|--no-cors',


### PR DESCRIPTION
Default value and coercion order are now inverted.

This seems to be the new undocumented behavior of commander. See: https://github.com/tj/commander.js/pull/829
