### PR TITLE
Ensure that container can be restarted

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,8 @@ _term() {
 
 trap _term TERM
 
+# Delete files if they were not cleaned by last run
+rm -rf /tmp/.X11-unix /tmp/.X99-lock
 
 start-stop-daemon --start --pidfile ~/xvfb.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset
 echo "Waiting 3 seconds for xvfb to start..."
@@ -19,5 +21,5 @@ node /usr/src/app/ -p 80 "$@" &
 child=$!
 wait "$child"
 
-start-stop-daemon --stop --pidfile ~/xvfb.pid # stop xvfb when exiting
+start-stop-daemon --stop --retry 5 --pidfile ~/xvfb.pid # stop xvfb when exiting
 rm ~/xvfb.pid


### PR DESCRIPTION
When the file `/tmp/.X99-lock` is available on startup of `Xvfb`, the process does not start.
So the script basically deletes this on startup. 
Usually, this file should be cleaned by the `Xfvb` process itself, that's why the `--retry` is specified. This waits for the process to exit for the defined period of time.