### PR TITLE
fix entrypoint to accept port as node parameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Petr Sloup <petr.sloup@klokantech.com>
 ENV NODE_ENV="production"
 VOLUME /data
 WORKDIR /data
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["/bin/bash", "/usr/src/app/run.sh"]
 
 RUN apt-get -qq update \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Alternatively, you can use the `tileserver-gl-light` package instead, which is p
 An alternative to npm to start the packed software easier is to install [Docker](http://www.docker.com/) on your computer and then run in the directory with the downloaded MBTiles the command:
 
 ```bash
-docker run --rm -it -v $(pwd):/data -p 8080:80 klokantech/tileserver-gl
+docker run --rm -it -v $(pwd):/data -p 8080:8080 klokantech/tileserver-gl
 ```
 
 This will download and start a ready to use container on your computer and the maps are going to be available in webbrowser on localhost:8080.

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ sleep 3
 export DISPLAY=:99.0
 
 cd /data
-node /usr/src/app/ -p 80 "$@" &
+node /usr/src/app/ "$@" &
 child=$!
 wait "$child"
 


### PR DESCRIPTION
**as:** a docker-compose user
**I want to:** be able of selecting any port for node server in docker image
**because:** I want to use host networking

This PR removes the `-p 80` in `run.sh`. In this way it is possible to put any parameter in the launch configuration of the containers. The default port is still 8080, and this is also now the exposed port in `Dockerfile`. The default behavior described in the doc is adapted like this in the doc: `docker run --rm -it -v $(pwd):/data -p 8080:8080 klokantech/tileserver-gl`.  But we can now use host networking with a custom port easily.

In alternative, we could change the default port in option of `src/main.js#37` to be port 80, if you prefer to keep the default port at 80 instead at 8080 for the container.


## EXAMPLES

### Using docker network
```
#~ docker run -it -p 7070:7070 danduk82/tileserver-gl -p 7070

Waiting 3 seconds for xvfb to start...
Starting tileserver-gl v2.4.0
Downloading sample data (zurich_switzerland.mbtiles) from https://github.com/klokantech/tileserver-gl/releases/download/v1.3.0/zurich_switzerland.mbtiles
Automatically creating config file for zurich_switzerland.mbtiles
Run with --verbose to see the config file here.
Starting server
Listening at http://[::]:7070/
Startup complete
[...]

#~ curl -I localhost:7070

HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: text/html; charset=utf-8
Content-Length: 4142
ETag: W/"102e-z0gKIpwdrJrNHBrSq0GZlWImfq4"
Date: Tue, 25 Sep 2018 19:18:38 GMT
Connection: keep-alive
```

### Using host network
```
#~ docker run -it --net=host danduk82/tileserver-gl -p 5555

Waiting 3 seconds for xvfb to start...
Starting tileserver-gl v2.4.0
Downloading sample data (zurich_switzerland.mbtiles) from https://github.com/klokantech/tileserver-gl/releases/download/v1.3.0/zurich_switzerland.mbtiles
Automatically creating config file for zurich_switzerland.mbtiles
Run with --verbose to see the config file here.
Starting server
Listening at http://[::]:5555/
Startup complete


#~ curl -I localhost:5555

HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: text/html; charset=utf-8
Content-Length: 4142
ETag: W/"102e-RdBQMG8nSzRO3WuVGa1ArbI3wIY"
Date: Tue, 25 Sep 2018 19:25:01 GMT
Connection: keep-alive
```

