### PR TITLE
new mapbox-gl-native version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "mocha test/**.js --timeout 10000"
   },
   "dependencies": {
-    "@mapbox/mapbox-gl-native": "3.5.4",
+    "@mapbox/mapbox-gl-native": "4.0.0",
     "@mapbox/mbtiles": "0.10.0",
     "@mapbox/sphericalmercator": "1.1.0",
     "@mapbox/vector-tile": "1.3.1",


### PR DESCRIPTION
According to https://github.com/mapbox/mapbox-gl-native/blob/master/platform/node/CHANGELOG.md there is no broken features.
Previous version is not buildable now.

> @mapbox/mapbox-gl-native@3.5.4 install /home/ubuntu/maps/node_modules/@mapbox/mapbox-gl-native
> node-pre-gyp install --fallback-to-build=false || make node
```
node-pre-gyp ERR! install error 
node-pre-gyp ERR! stack Error: 403 status code downloading tarball https://mapbox-node-binary.s3.amazonaws.com/@mapbox/mapbox-gl-native/v3.5.4/node-v57-linux-x64-Release.tar.gz
```