### PR TITLE
Correctly retrieve the public_url parameter on start

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -43,7 +43,7 @@ var opts = require('commander')
     'Disable Cross-origin resource sharing headers'
   )
   .option(
-    '-u|--public_url',
+    '-u|--public_url <url>',
     'Enable exposing the server on subpaths, not necessarily the root of the domain'
   )
   .option(


### PR DESCRIPTION
The `public_url` option is not correctly retrieved and make the program crash.
This PR hence fixes #230.