### PR TITLE
Removes body data from http 204 response

### DIFF
--- a/src/serve_data.js
+++ b/src/serve_data.js
@@ -89,7 +89,7 @@ module.exports = function(options, repo, params, id, styles, publicUrl) {
     source.getTile(z, x, y, function(err, data, headers) {
       if (err) {
         if (/does not exist/.test(err.message)) {
-          return res.status(204).send(err.message);
+          return res.status(204).send();
         } else {
           return res.status(500).send(err.message);
         }


### PR DESCRIPTION
The HTTP 1.1 specification states the following on the [204 No content status code definition](https://tools.ietf.org/html/rfc2616#page-60):

> The 204 response MUST NOT include a message-body, and thus is always
>    terminated by the first empty line after the header fields.

Some Vector Tile libraries (at least Mapbox GL Native and Mapbox GL React Native) throw an error if a body message is present on an HTTP response with the 204 status code. This PR removes the body message from the response when an HTTP 204 response is sent.
