### PR TITLE
let the user define a log file or a log format

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -54,6 +54,14 @@ var opts = require('commander')
     '-s, --silent',
     'Less verbose output'
   )
+  .option(
+    '-l|--log_file <file>',
+    'output log file (defaults to standard out)'
+  )
+  .option(
+    '-f|--log_format <format>',
+    'define the log format:  https://github.com/expressjs/morgan#morganformat-options'
+  )
   .version(
     packageJson.version,
     '-v, --version'
@@ -74,6 +82,8 @@ var startServer = function(configPath, config) {
     port: opts.port,
     cors: opts.cors,
     silent: opts.silent,
+    logFile: opts.log_file,
+    logFormat: opts.log_format,
     publicUrl: publicUrl
   });
 };

--- a/src/server.js
+++ b/src/server.js
@@ -41,12 +41,11 @@ function start(opts) {
 
   app.enable('trust proxy');
 
-  if (process.env.NODE_ENV == 'production') {
-    app.use(morgan('tiny', {
-      skip: function(req, res) { return opts.silent && (res.statusCode == 200 || res.statusCode == 304) }
-    }));
-  } else if (process.env.NODE_ENV !== 'test') {
-    app.use(morgan('dev', {
+  if (process.env.NODE_ENV !== 'test') {
+    var defaultLogFormat = process.env.NODE_ENV == 'production' ? 'tiny' : 'dev';
+    var logFormat = opts.logFormat || defaultLogFormat;
+    app.use(morgan(logFormat, {
+      stream: opts.logFile ? fs.createWriteStream(opts.logFile, { flags: 'a' }) : process.stdout,
       skip: function(req, res) { return opts.silent && (res.statusCode == 200 || res.statusCode == 304) }
     }));
   }


### PR DESCRIPTION
let the user define a log file or a log format:

log file defaults to standard out.

log format defaults to current behavior ('tiny' for production, 'dev' for dev, and not enabled in test)