### PR TITLE
Use verbose flag to debug corrupted mbtiles

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,7 @@ var startServer = function(configPath, config) {
     bind: opts.bind,
     port: opts.port,
     cors: opts.cors,
+    verbose: opts.verbose,
     silent: opts.silent,
     logFile: opts.log_file,
     logFormat: opts.log_format,

--- a/src/serve_rendered.js
+++ b/src/serve_rendered.js
@@ -177,7 +177,7 @@ module.exports = function(options, repo, params, id, publicUrl, dataResolver) {
                 format = parts[5].split('.')[1];
             source.getTile(z, x, y, function(err, data, headers) {
               if (err) {
-                //console.log('MBTiles error, serving empty', err);
+                if (options.verbose) console.log('MBTiles error, serving empty', err);
                 createEmptyResponse(sourceInfo.format, sourceInfo.color, callback);
                 return;
               }


### PR DESCRIPTION
Verbose flag used to added additional error messages to critical errors, such as

https://github.com/klokantech/tileserver-gl/issues/323

in the process of cloning the apparent SQLITE_CORRUPT database as follows:

```
!#/bin/sh
#dump command in sqlite3 and pipe to sqlite3 insert into new database
sqlite3 planet.mbtiles ".dump" | sqlite3 new.db
```